### PR TITLE
Add ExpectedHex function

### DIFF
--- a/sri.go
+++ b/sri.go
@@ -170,3 +170,8 @@ func toHex(expected []string) []string {
 func (c *Checker) Expected(name string) []string {
 	return c.expected[name]
 }
+
+// ExpectedHex returns the expected hashes for the given hash name, hex-encoded.
+func (c *Checker) ExpectedHex(name string) []string {
+	return toHex(c.Expected(name))
+}

--- a/sri_test.go
+++ b/sri_test.go
@@ -141,3 +141,24 @@ sha512-jt9sSgTPOFnKQWLknlJEWjBq6UaOcjZzJOwlSgaEWr1b8IfmBmOMJZ91TmrZzjbUUB211oxxK
 	}, c.Expected("sha512"))
 	assert.Nil(t, c.Expected("md5"))
 }
+
+func TestExpectedHex(t *testing.T) {
+	c, err := NewChecker(`
+sha256-y1v31NktLrKLVp1gbS7zjWtYgDICENEw7hKLJHcw4E0=
+sha384-4QuseiT9WQ+80EDZ/MYTodasdNBTLIC/9G1XmSQDmTjTvDM8q00Vgxa9nMgwUw3j
+sha512-xLpYEEen45RJnXxmFACS66+sO/1Xuo192Xq6uIarYI4uE7MZevI2pTyoKUZAFVP9tvfhJTS6YjOJcMc8ckoRkw==
+sha256-49hwASqGvw3v5oq2Pu4U2jR2Pv9KCMm2VGFAqCwEXhI=
+sha384-ixBUOCmT6wnGpEL5AxEsAm9EdJCBj7kF099SUkvIbtB63ydFdgNgXVj784BCcJ2k
+sha512-jt9sSgTPOFnKQWLknlJEWjBq6UaOcjZzJOwlSgaEWr1b8IfmBmOMJZ91TmrZzjbUUB211oxxKEjyOBQHeXiDoA==
+`)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{
+		"cb5bf7d4d92d2eb28b569d606d2ef38d6b5880320210d130ee128b247730e04d",
+		"e3d870012a86bf0defe68ab63eee14da34763eff4a08c9b6546140a82c045e12",
+	}, c.ExpectedHex("sha256"))
+	assert.Equal(t, []string{
+		"c4ba581047a7e394499d7c66140092ebafac3bfd57ba8d7dd97abab886ab608e2e13b3197af236a53ca82946401553fdb6f7e12534ba62338970c73c724a1193",
+		"8edf6c4a04cf3859ca4162e49e52445a306ae9468e72367324ec254a06845abd5bf087e606638c259f754e6ad9ce36d4501db5d68c712848f2381407797883a0",
+	}, c.ExpectedHex("sha512"))
+	assert.Equal(t, 0, len(c.ExpectedHex("md5")))
+}


### PR DESCRIPTION
We already have toHex, which I don't really want to expose since it doesn't check any errors (so it's safe in this context where we know they're all well-formed but not as a general function)